### PR TITLE
Fix broken Oracle jdk download link and downgrade gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains only the source code of the package.
 
 * Download and install Java SE Development Kit (JDK) version 17 (from one of the following locations).
 
-   * [Oracle](https://www.oracle.com/java/technologies/javase-jdk17-downloads.html)
+   * [Oracle](https://www.oracle.com/java/technologies/downloads/)
    
    * [OpenJDK](https://adoptium.net/)
    

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ version=1.0.2-SNAPSHOT
 
 ballerinaLangVersion=2201.5.0
 
-ballerinaGradlePluginVersion=1.0.0
+ballerinaGradlePluginVersion=2.0.0
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 githubSpotbugsVersion=5.0.14
-githubJohnrengelmanShadowVersion=8.1.0
+githubJohnrengelmanShadowVersion=7.1.2
 underCouchDownloadVersion=5.4.0
 researchgateReleaseVersion=2.8.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Purpose
Java 17 migration
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
