### PR TITLE
Revert "chore: sync main branch after 1.2.1 release"

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "math.vector"
-version = "1.2.1"
+version = "1.2.0"
 authors = ["Ballerina"]
 keywords = ["math", "vector", "distance"]
 repository = "https://github.com/ballerina-platform/module-ballerina-math.vector"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -51,7 +51,7 @@ scope = "testOnly"
 [[package]]
 org = "ballerina"
 name = "math.vector"
-version = "1.2.1"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "test"}
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.2.2-SNAPSHOT
+version=1.2.1-SNAPSHOT
 
 ballerinaLangVersion=2201.12.0
 


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Reverted the previous main-branch sync after the 1.2.1 release by rolling package and project versions back to the pre-release state. Updated `math.vector` in `Ballerina.toml` and `Dependencies.toml` from `1.2.1` to `1.2.0`, and adjusted `gradle.properties` from `1.2.2-SNAPSHOT` to `1.2.1-SNAPSHOT` to keep versioning aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->